### PR TITLE
Update dev slot workflow configuration

### DIFF
--- a/.github/workflows/frontend-dev-slot.yml
+++ b/.github/workflows/frontend-dev-slot.yml
@@ -44,17 +44,17 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
 
-      - name: Update dev slot container image
+      - name: Update dev-slot container image
         run: |
           az webapp config container set \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WEBAPP_NAME }} \
-            --slot dev \
+            --slot dev-slot \
             --docker-custom-image-name ${{ env.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ env.TAG }} \
             --docker-registry-server-url https://${{ env.ACR_LOGIN_SERVER }} \
             --docker-registry-server-user ${{ secrets.ACR_USERNAME }} \
             --docker-registry-server-password ${{ secrets.ACR_PASSWORD }}
 
-      - name: Restart dev slot
+      - name: Restart dev-slot
         run: |
-          az webapp restart --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name ${{ secrets.AZURE_WEBAPP_NAME }} --slot dev
+          az webapp restart --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name ${{ secrets.AZURE_WEBAPP_NAME }} --slot dev-slot

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ either by deleting the resource group in the Portal or running `azd down`.
 
  
 ### Deploying Feature Branches
-Use the `frontend-dev-slot.yml` workflow to build the React frontend from `Feature-001` and update the dev slot with the resulting Docker image. This allows testing UI changes before merging into `main`.
+Use the `frontend-dev-slot.yml` workflow to build the React frontend from `Feature-001` and update the `dev-slot` with the resulting Docker image. This allows testing UI changes before merging into `main`.
 
 <br /><br />
 <h2><img src="./docs/images/readme/business-scenario.png" width="48" />


### PR DESCRIPTION
## Summary
- adjust README dev slot docs
- point GitHub Actions workflow to `dev-slot`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.backend.context.cosmos_memory')*

------
https://chatgpt.com/codex/tasks/task_b_6882cefcb2d0833299e4eb200d319be6