### PR TITLE
Configure dev slot deployment

### DIFF
--- a/.github/workflows/deploy-devslot.yml
+++ b/.github/workflows/deploy-devslot.yml
@@ -1,0 +1,34 @@
+name: Deploy features-001 to dev slot
+
+on:
+  workflow_run:
+    workflows: ["Build Docker and Optional Push"]
+    branches: ["features-001"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Deploy container image to dev slot
+        run: |
+          az webapp config container set \
+            --name app-macae-novkmzdbkmlk \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --slot dev-slot \
+            --docker-custom-image-name ${{ secrets.ACR_LOGIN_SERVER }}/macaefrontend:features-001 \
+            --docker-registry-server-url https://${{ secrets.ACR_LOGIN_SERVER }} \
+            --docker-registry-server-user ${{ secrets.ACR_USERNAME }} \
+            --docker-registry-server-password ${{ secrets.ACR_PASSWORD }}
+      - name: Restart app
+        run: az webapp restart --name app-macae-novkmzdbkmlk --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --slot dev-slot
+

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Follow the quick deploy steps on the deployment guide to deploy this solution to
 
 ### Developing on `features-001`
 
+When collaborating through Better Process Group's GitHub Enterprise server, clone or fork this repository from `https://git.betterprocessgroup.com` so that internal CI/CD runs correctly. Work from the `features-001` branch before submitting changes back to `main`.
+
 This repository uses a development slot in Azure App Service for fast validation.
 Push commits to the `features-001` branch and the code will automatically deploy to the
 [`dev-slot` environment](https://app-macae-novkmzdbkmlk-dev-slot.azurewebsites.net).


### PR DESCRIPTION
## Summary
- document how to develop on `features-001`
- add GitHub Enterprise note for betterprocessgroup users
- deploy `features-001` branch to the `dev-slot` App Service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: azure)*

------
https://chatgpt.com/codex/tasks/task_b_6882e8440ad083328227ee5a5e65fb46