### PR TITLE
Fix WEBSITES_PORT for frontend container

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1083,7 +1083,8 @@ module webSite 'br/public:avm/res/web/site:0.15.1' = if (webSiteEnabled) {
     appSettingsKeyValuePairs: {
       SCM_DO_BUILD_DURING_DEPLOYMENT: 'true'
       DOCKER_REGISTRY_SERVER_URL: 'https://${webSiteConfiguration.?containerImageRegistryDomain ?? 'macaeregis.azurecr.io'}'
-      WEBSITES_PORT: '3000'
+      // Use port 80 to match the Dockerfile's default uvicorn port
+      WEBSITES_PORT: '80'
       WEBSITES_CONTAINER_START_TIME_LIMIT: '1800' // 30 minutes, adjust as needed
       BACKEND_API_URL: 'https://${containerApp.outputs.fqdn}'
       AUTH_ENABLED: 'false'

--- a/infra/old/macae-continer-oc.json
+++ b/infra/old/macae-continer-oc.json
@@ -423,7 +423,7 @@
             },
             {
               "name": "WEBSITES_PORT",
-              "value": "3000"
+              "value": "80"
             },
             {
               "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",

--- a/infra/old/macae-continer.json
+++ b/infra/old/macae-continer.json
@@ -423,7 +423,7 @@
             },
             {
               "name": "WEBSITES_PORT",
-              "value": "3000"
+              "value": "80"
             },
             {
               "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",

--- a/infra/old/macae.bicep
+++ b/infra/old/macae.bicep
@@ -337,7 +337,7 @@ resource frontendAppService 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITES_PORT'
-          value: '3000'
+          value: '80'
         }
         {
           name: 'WEBSITES_CONTAINER_START_TIME_LIMIT'  // Add startup time limit

--- a/infra/old/main.bicep
+++ b/infra/old/main.bicep
@@ -1085,7 +1085,7 @@ module webSite 'br/public:avm/res/web/site:0.15.1' = {
       {
         SCM_DO_BUILD_DURING_DEPLOYMENT: 'true'
         DOCKER_REGISTRY_SERVER_URL: 'https://macaeregis.azurecr.io'
-        WEBSITES_PORT: '3000'
+        WEBSITES_PORT: '80'
         WEBSITES_CONTAINER_START_TIME_LIMIT: '1800' // 30 minutes, adjust as needed
         BACKEND_API_URL: 'https://${containerApp.outputs.fqdn}'
         AUTH_ENABLED: 'false'

--- a/infra/old/resources.bicep
+++ b/infra/old/resources.bicep
@@ -182,7 +182,7 @@ module frontend 'br/public:avm/res/app/container-app:0.8.0' = {
   name: 'frontend'
   params: {
     name: 'frontend'
-    ingressTargetPort: 3000
+  ingressTargetPort: 80
     scaleMinReplicas: 1
     scaleMaxReplicas: 10
     secrets: {
@@ -212,7 +212,7 @@ module frontend 'br/public:avm/res/app/container-app:0.8.0' = {
           }
           {
             name: 'PORT'
-            value: '3000'
+              value: '80'
           }
         ],
         frontendEnv,


### PR DESCRIPTION
## Summary
- align the web app configuration with container port

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4' and missing env vars)*

------
https://chatgpt.com/codex/tasks/task_b_68833ef486fc8332973dc5574e1cb1c3