### PR TITLE
feat: Update workflows and add Codespaces guide

### DIFF
--- a/.github/workflows/deploy-waf.yml
+++ b/.github/workflows/deploy-waf.yml
@@ -73,9 +73,9 @@ jobs:
         id: generate_rg_name
         run: |
           echo "Generating a unique resource group name..."
-          ACCL_NAME="macae"  # Account name as specified
-          SHORT_UUID=$(uuidgen | cut -d'-' -f1)
-          UNIQUE_RG_NAME="arg-${ACCL_NAME}-${SHORT_UUID}"
+          ACCL_NAME="macae"
+          SHORT_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z' | head -c 12)
+          UNIQUE_RG_NAME="arg-${ACCL_NAME}-${SHORT_SUFFIX}"
           echo "RESOURCE_GROUP_NAME=${UNIQUE_RG_NAME}" >> $GITHUB_ENV
           echo "Generated Resource_GROUP_PREFIX: ${UNIQUE_RG_NAME}"
 
@@ -95,10 +95,9 @@ jobs:
       - name: Generate Unique Solution Prefix
         id: generate_solution_prefix
         run: |
-          COMMON_PART="macae"
-          TIMESTAMP=$(date +%s)
-          UPDATED_TIMESTAMP=$(echo $TIMESTAMP | tail -c 6)
-          UNIQUE_SOLUTION_PREFIX="${COMMON_PART}${UPDATED_TIMESTAMP}"
+          COMMON_PART="macae-"
+          UNIQUE_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z' | head -c 12)
+          UNIQUE_SOLUTION_PREFIX="${COMMON_PART}${UNIQUE_SUFFIX}"
           echo "SOLUTION_PREFIX=${UNIQUE_SOLUTION_PREFIX}" >> $GITHUB_ENV
 
       - name: Deploy Bicep Template

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,8 +89,8 @@ jobs:
         id: generate_rg_name
         run: |
           ACCL_NAME="macae"
-          SHORT_UUID=$(uuidgen | cut -d'-' -f1)
-          UNIQUE_RG_NAME="arg-${ACCL_NAME}-${SHORT_UUID}"
+          SHORT_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z' | head -c 12)
+          UNIQUE_RG_NAME="arg-${ACCL_NAME}-${SHORT_SUFFIX}"
           echo "RESOURCE_GROUP_NAME=${UNIQUE_RG_NAME}" >> $GITHUB_ENV
           echo "Generated Resource_GROUP_PREFIX: ${UNIQUE_RG_NAME}"
 
@@ -107,10 +107,9 @@ jobs:
       - name: Generate Unique Solution Prefix
         id: generate_solution_prefix
         run: |
-          COMMON_PART="macae"
-          TIMESTAMP=$(date +%s)
-          UPDATED_TIMESTAMP=$(echo $TIMESTAMP | tail -c 6)
-          UNIQUE_SOLUTION_PREFIX="${COMMON_PART}${UPDATED_TIMESTAMP}"
+          COMMON_PART="macae-"
+          UNIQUE_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z' | head -c 12)
+          UNIQUE_SOLUTION_PREFIX="${COMMON_PART}${UNIQUE_SUFFIX}"
           echo "SOLUTION_PREFIX=${UNIQUE_SOLUTION_PREFIX}" >> $GITHUB_ENV
 
       - name: Deploy Bicep Template

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ This repository uses a development slot in Azure App Service for fast validation
 Push commits to the `features-001` branch and the code will automatically deploy to the
 [`dev-slot` environment](https://app-macae-novkmzdbkmlk-dev-slot.azurewebsites.net).
 
+For a step-by-step tutorial on editing in Visual Studio Codespaces and previewing your changes before committing, see [Codespaces Developer Guide](./docs/CodespacesDeveloperGuide.md).
+
 1. Create a feature branch if you haven't already:
    ```bash
    git checkout -b features-001

--- a/docs/CodespacesDeveloperGuide.md
+++ b/docs/CodespacesDeveloperGuide.md
@@ -1,0 +1,48 @@
+# Working in Visual Studio Codespaces
+
+This guide walks Better Process Group developers through editing the Multi-Agent Custom Automation Engine solution accelerator using Visual Studio Codespaces and previewing changes before committing.
+
+## Prerequisites
+
+- Access to the BPG GitHub Enterprise repository.
+- Permission to create Codespaces.
+- An Azure subscription that already contains the resources listed in the deployment overview.
+
+## Opening the repository in Codespaces
+
+1. Navigate to your fork or the main repository in GitHub Enterprise.
+2. Select **Code** > **Codespaces** and click **Create codespace**.
+3. Choose the branch you want to work on (typically `features-001`).
+4. Wait for the container to initialize. A browser-based VS Code window opens.
+
+## Making changes
+
+1. Use the built-in terminal to create a new feature branch if needed:
+   ```bash
+   git checkout -b my-feature
+   ```
+2. Edit files directly in the Codespace using VS Code.
+3. Save your changes. The development container automatically builds your project so you can run the backend and frontend locally:
+   ```bash
+   cd src/backend && python app_kernel.py
+   # In another terminal
+   cd src/frontend && python frontend_server.py
+   ```
+4. Open <http://localhost:3000> within the Codespace browser preview to verify your modifications.
+
+## Committing and pushing
+
+1. Stage and commit your changes via the VS Code Source Control view or command line:
+   ```bash
+   git add .
+   git commit -m "Describe your change"
+   ```
+2. Push the branch to GitHub Enterprise:
+   ```bash
+   git push --set-upstream origin my-feature
+   ```
+3. When ready, open a pull request against `features-001` or `main`.
+
+Once pushed, GitHub Actions builds Docker images and deploys to the `dev-slot` environment at
+`https://app-macae-novkmzdbkmlk-dev-slot.azurewebsites.net` so you can preview the running app.
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = -p pytest_asyncio
+# Only run backend tests by default
+testpaths = src/backend/tests

--- a/src/backend/tests/context/test_cosmos_memory.py
+++ b/src/backend/tests/context/test_cosmos_memory.py
@@ -1,7 +1,28 @@
+import os
+import sys
 import pytest
 from unittest.mock import AsyncMock, patch
 from azure.cosmos.partition_key import PartitionKey
-from src.backend.context.cosmos_memory import CosmosBufferedChatCompletionContext
+
+# Provide minimal environment variables required during import
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://mock-openai-endpoint")
+os.environ.setdefault("AZURE_OPENAI_API_VERSION", "2023-01-01")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT_NAME", "mock-deployment-name")
+os.environ.setdefault("COSMOSDB_ENDPOINT", "https://mock-endpoint")
+os.environ.setdefault("COSMOSDB_KEY", "mock-key")
+os.environ.setdefault("COSMOSDB_DATABASE", "mock-database")
+os.environ.setdefault("COSMOSDB_CONTAINER", "mock-container")
+os.environ.setdefault("AZURE_AI_SUBSCRIPTION_ID", "dummy-subscription")
+os.environ.setdefault("AZURE_AI_RESOURCE_GROUP", "dummy-rg")
+os.environ.setdefault("AZURE_AI_PROJECT_NAME", "dummy-project")
+os.environ.setdefault("AZURE_AI_AGENT_ENDPOINT", "https://dummy-endpoint")
+
+# Ensure src/backend is on the Python path for imports
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+from src.backend.context.cosmos_memory_kernel import CosmosMemoryContext
 
 
 # Helper to create async iterable
@@ -49,8 +70,13 @@ def mock_config(mock_cosmos_client):
     """Fixture to patch Config with mock Cosmos DB client."""
     mock_client, _, _ = mock_cosmos_client
     with patch(
-        "src.backend.config.Config.GetCosmosDatabaseClient", return_value=mock_client
-    ), patch("src.backend.config.Config.COSMOSDB_CONTAINER", "mock-container"):
+        "src.backend.config_kernel.Config.COSMOSDB_CONTAINER", "mock-container"
+    ), patch(
+        "src.backend.context.cosmos_memory_kernel.CosmosClient"
+    ) as MockCosmosClient, patch(
+        "src.backend.context.cosmos_memory_kernel.DefaultAzureCredential"
+    ):
+        MockCosmosClient.return_value.get_database_client.return_value = mock_client
         yield
 
 
@@ -58,7 +84,7 @@ def mock_config(mock_cosmos_client):
 async def test_initialize(mock_config, mock_cosmos_client):
     """Test if the Cosmos DB container is initialized correctly."""
     mock_client, mock_container, _ = mock_cosmos_client
-    context = CosmosBufferedChatCompletionContext(
+    context = CosmosMemoryContext(
         session_id="test_session", user_id="test_user"
     )
     await context.initialize()

--- a/src/backend/tests/models/test_messages.py
+++ b/src/backend/tests/models/test_messages.py
@@ -1,9 +1,17 @@
 # File: test_message.py
 
+import os
+import sys
 import uuid
-from src.backend.models.messages import (
+
+# Ensure src/backend is on the Python path for imports
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+from src.backend.models.messages_kernel import (
     DataType,
-    BAgentType,
+    AgentType,
     StepStatus,
     PlanStatus,
     HumanFeedbackStatus,
@@ -20,7 +28,7 @@ def test_enum_values():
     """Test enumeration values for consistency."""
     assert DataType.session == "session"
     assert DataType.plan == "plan"
-    assert BAgentType.human_agent == "HumanAgent"
+    assert AgentType.HUMAN.value == "Human_Agent"
     assert StepStatus.completed == "completed"
     assert PlanStatus.in_progress == "in_progress"
     assert HumanFeedbackStatus.requested == "requested"
@@ -31,7 +39,7 @@ def test_plan_with_steps_update_counts():
     step1 = Step(
         plan_id=str(uuid.uuid4()),
         action="Review document",
-        agent=BAgentType.human_agent,
+        agent=AgentType.HUMAN,
         status=StepStatus.completed,
         session_id=str(uuid.uuid4()),
         user_id=str(uuid.uuid4()),
@@ -39,7 +47,7 @@ def test_plan_with_steps_update_counts():
     step2 = Step(
         plan_id=str(uuid.uuid4()),
         action="Approve document",
-        agent=BAgentType.hr_agent,
+        agent=AgentType.HR,
         status=StepStatus.failed,
         session_id=str(uuid.uuid4()),
         user_id=str(uuid.uuid4()),
@@ -78,10 +86,10 @@ def test_action_request_creation():
         plan_id=str(uuid.uuid4()),
         session_id=str(uuid.uuid4()),
         action="Review and approve",
-        agent=BAgentType.procurement_agent,
+        agent=AgentType.PROCUREMENT,
     )
     assert action_request.action == "Review and approve"
-    assert action_request.agent == BAgentType.procurement_agent
+    assert action_request.agent == AgentType.PROCUREMENT
 
 
 def test_human_feedback_creation():
@@ -114,7 +122,7 @@ def test_step_defaults():
     step = Step(
         plan_id=str(uuid.uuid4()),
         action="Prepare report",
-        agent=BAgentType.generic_agent,
+        agent=AgentType.GENERIC,
         session_id=str(uuid.uuid4()),
         user_id=str(uuid.uuid4()),
     )


### PR DESCRIPTION
## Summary
- add a new Codespaces developer guide for BPG developers
- link the new guide from the README
- generate resource names with random 12-character suffixes in deployment workflows
- fix test suite imports and expectations, restrict pytest to backend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883e40ded3083328986de22334adc27